### PR TITLE
Update Change Jupyter Notebook startup folder(Win)

### DIFF
--- a/docs/execute.rst
+++ b/docs/execute.rst
@@ -30,7 +30,7 @@ Change Jupyter Notebook startup folder (Windows)
 
 - Copy the *Jupyter Notebook* launcher from the menu to the desktop.
 
-- Right click on the new launcher and change the "Start in" field by pasting
+- Right click on the new launcher and change the `Target field`, change *%USERPROFILE%* to 
   the full path of the folder which will contain all the notebooks.
 
 - Double-click on the *Jupyter Notebook* desktop launcher (icon shows [IPy]) to start the


### PR DESCRIPTION
[The way to change Jupyter Notebook startup folder](http://jupyter-notebook-beginner-guide.readthedocs.io/en/latest/execute.html#change-jupyter-notebook-startup-folder-windows) doesn't work on WIN10 64bit Anaconda3.Follow  [this answer](https://stackoverflow.com/a/44104736/1278112) I got it right.Sorry,if the formatting is not as your desired.