### PR TITLE
Update "See also:" section links in what_is_jupyter.rst

### DIFF
--- a/docs/what_is_jupyter.rst
+++ b/docs/what_is_jupyter.rst
@@ -100,11 +100,9 @@ Official Documentation:
 
 See also:
 
-- `What is the IPython Notebook? <https://github.com/jupyter/notebook/blob/main/docs/source/examples/Notebook/What%20is%20the%20Jupyter%20Notebook.ipynb>`__
+- `What is the Jupyter Notebook? <https://nbviewer.org/github/jupyter/notebook/blob/main/docs/source/examples/Notebook/What%20is%20the%20Jupyter%20Notebook.ipynb>`__
 
-- `Notebook Basics <https://github.com/jupyter/notebook/blob/main/docs/source/examples/Notebook/Notebook%20Basics.ipynb>`__, an example notebook
-
-- `Introducing IPython Notebook <http://opentechschool.github.io/python-data-intro/core/notebook.html>`__
+- `Notebook Basics <https://nbviewer.org/github/jupyter/notebook/blob/main/docs/source/examples/Notebook/Notebook%20Basics.ipynb>`__, an example notebook
 
 - `Jupyter Notebook: The Definitive Guide <https://www.datacamp.com/community/tutorials/tutorial-jupyter-notebook>`__, an introductory tutorial to Jupyter
 

--- a/docs/what_is_jupyter.rst
+++ b/docs/what_is_jupyter.rst
@@ -100,9 +100,9 @@ Official Documentation:
 
 See also:
 
-- `What is the IPython Notebook? <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/What%20is%20the%20Jupyter%20Notebook.ipynb#>`__
+- `What is the IPython Notebook? <https://github.com/jupyter/notebook/blob/main/docs/source/examples/Notebook/What%20is%20the%20Jupyter%20Notebook.ipynb>`__
 
-- `Notebook Basics <http://nbviewer.jupyter.org/github/jupyter/notebook/blob/master/docs/source/examples/Notebook/Notebook%20Basics.ipynb>`__, an example notebook
+- `Notebook Basics <https://github.com/jupyter/notebook/blob/main/docs/source/examples/Notebook/Notebook%20Basics.ipynb>`__, an example notebook
 
 - `Introducing IPython Notebook <http://opentechschool.github.io/python-data-intro/core/notebook.html>`__
 


### PR DESCRIPTION
I am learning Jupyter and wanted to click some links, but they are 404-ing. I have updated the two links that still exist from Jupyter's github + removed one that hasn't been updated in 6+ years.

https://github.com/OpenTechSchool/python-data-intro/tree/gh-pages/core

![image](https://github.com/tritemio/jupyter_notebook_beginner_guide/assets/2483953/63a44871-2537-4fa1-b47f-e763d26b0008)

I can add it back if we still think it's valuable though, probably the rest of the links / the official doc covers most of it though.

